### PR TITLE
Bugfix for AttributeError:

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fixes the [InsecurePlatformWarning](https://urllib3.readthedocs.org/en/latest/se
 
 #### Variables
 
-None
+* `insecure_platform_warning_conflicting` [default: `[]`]: Conflicting packages to remove (e.g. `[python-openssl]`)
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 # defaults file for insecure-platform-warning
 ---
+insecure_platform_warning_conflicting: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,16 @@
     - insecure-platform-warning
     - insecure-platform-warning-dependencies
 
+- name: remove conflicting
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items: insecure_platform_warning_conflicting
+  tags:
+    - configuration
+    - insecure-platform-warning
+    - insecure-platform-warning-conflicting
+
 - name: upgrade
   pip:
     name: "{{ item }}"


### PR DESCRIPTION
`AttributeError: '_socketobject' object has no attribute 'set_tlsext_host_name'`

This was an error that I encountered on a non-fresh Ubuntu 12.04 machine, remove the `apt` package `python-openssl` fixed the problem.
